### PR TITLE
Rename mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - json_keyfile (string, required): credential file path or `content` string
 - spreadsheet_url (string, required): your spreadsheet's url
 - worksheet_title (string, required): worksheet's title
-- mode (string, default: append): writing record method, available mode are `append` and `replace`
+- mode (string, default: append_direct): writing record method, available mode are `append_direct` and `delete_in_advance`
 - header_line (bool, default: false): if true, write header to first record
 - start_row (integer, default: 1): specific the start row
 - start_column (integer, default: 1): specific the start column
@@ -58,6 +58,16 @@ out:
   default_timestamp_format: "%Y-%m-%d %H:%M:%S %z"
 ```
 
+## Mode
+
+* append_direct
+  * Behavior: This modes appends rows to the target worksheet directly. If the target worksheet doesn't exist, it is created automatically
+  * Transactional: No. If fails, the target worksheet could have some rows inserted.
+  * Resumable: No.
+* delete_in_advance
+  * Behavior: Delete rows to be appended first, then `append_direct`.
+  * Transactional: No. Users may see all rows are once deleted. Also, if fails, the target worksheet could have some rows inserted.
+  * Resumable: No.
 
 ## Build
 

--- a/lib/embulk/output/google_spreadsheets.rb
+++ b/lib/embulk/output/google_spreadsheets.rb
@@ -37,7 +37,7 @@ module Embulk
 
           # optional
           "auth_method"      => config.param("auth_method",       :string,  default: "authorized_user"), # 'auth_method' or 'service_account'
-          "mode"             => config.param("mode",              :string,  default: "append"), # `replace` or `append`
+          "mode"             => config.param("mode",              :string,  default: "append_direct"), # `append_direct` or `delete_in_advance`
           "header_line"      => config.param("header_line",       :bool,    default: false),
           "start_column"     => config.param("start_column",      :integer, default: 1),
           "start_row"        => config.param("start_row",         :integer, default: 1),
@@ -50,7 +50,7 @@ module Embulk
         task["default_timezone"] = "+00:00" if task["default_timezone"] == 'UTC'
 
         mode = task["mode"].to_sym
-        raise "unsupported mode: #{mode.inspect}" unless [:append, :replace].include? mode
+        raise "unsupported mode: #{mode.inspect}" unless [:append_direct, :delete_in_advance].include? mode
 
         worksheet = build_worksheet_client(task)
 
@@ -59,7 +59,7 @@ module Embulk
         #
         determine_start_index(worksheet, task, schema, mode)
 
-        if mode == :replace
+        if mode == :delete_in_advance
           clean_previous_records(worksheet, schema, task)
         end
 
@@ -138,7 +138,7 @@ module Embulk
         task["col_index"] = c = task["start_column"]
         previous_record_exists = false
 
-        if mode == :append
+        if mode == :append_direct
           column_range = c...(c + schema.length)
           next_row_index = last_record_index(worksheet, column_range) + 1
 


### PR DESCRIPTION
We, embulk plugin developers, usually put `_direct` to mode name if we directly modify the target and it is not transactional.

see also:

* https://github.com/embulk/embulk-output-bigquery/#mode
* https://github.com/embulk/embulk-output-jdbc/tree/master/embulk-output-mysql